### PR TITLE
Add new field to Google.Response.CalendarEvent

### DIFF
--- a/src/Google/Response.hs
+++ b/src/Google/Response.hs
@@ -84,6 +84,7 @@ instance Eq ZonedDateTime where
 
 data CalendarEvent = CalendarEvent
   { status :: Text
+  , organizer :: Account
   , creator :: Account
   , attendees :: Maybe [Account]
   , summary :: Maybe Text


### PR DESCRIPTION
Add `organizer` to Google.Response.CalendarEvent as field.  

Just for reference, I maked the [sample](https://github.com/mojamozya/tonatona-google-server-api/commit/7d3f8338c4f8663be11b5b8b1a14b41b69b7f540) and used it.  
As a result, I got 16 events from my calendar and it seemed to work fine.