### PR TITLE
Make it possible to manipulate extended properties

### DIFF
--- a/google-server-api.cabal
+++ b/google-server-api.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a0f7961e20660b0657db7262b80d50981c8e43c6eb3f88bfc556e0010bf9dc0b
+-- hash: 878d8dc1713fb77b94bbe1cd0dd820c4d4c3c8f87352f0932991651de17bce99
 
 name:           google-server-api
 version:        0.3.3.1
@@ -37,7 +37,46 @@ library
       Paths_google_server_api
   hs-source-dirs:
       src
-  default-extensions: BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable DoAndIfThenElse DuplicateRecordFields EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings PartialTypeSignatures PatternGuards PolyKinds RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving Strict StrictData TupleSections TypeFamilies TypeSynonymInstances ViewPatterns
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      DoAndIfThenElse
+      DuplicateRecordFields
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      Strict
+      StrictData
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       HsOpenSSL >=0.11.4.13 && <0.12

--- a/src/Google/Client.hs
+++ b/src/Google/Client.hs
@@ -45,6 +45,7 @@ import Servant.API
   , JSON
   , Post
   , QueryParam
+  , QueryParams
   , ReqBody
   , ToHttpApiData
   )
@@ -67,6 +68,7 @@ import Google.JWT (JWT)
 import qualified Google.JWT as JWT
 import qualified Google.Response as Response
 import qualified Google.Type as Type
+import Google.Form (ExtendedProperty)
 
 #if !MIN_VERSION_servant(0, 16, 0)
 type ClientError = ServantError
@@ -98,6 +100,8 @@ type API
     QueryParam "timeMin" Form.DateTime :>
     QueryParam "timeMax" Form.DateTime :>
     QueryParam "orderBy" Text :>
+    QueryParams "privateExtendedProperty" ExtendedProperty :>
+    QueryParams "sharedExtendedProperty" ExtendedProperty :>
     Get '[ JSON] Response.CalendarEventList
   :<|> "calendar" :> "v3" :> "calendars" :>
     Capture "calendarId" Text :>
@@ -147,6 +151,8 @@ getCalendarEventList' ::
   -> Maybe Form.DateTime
   -> Maybe Form.DateTime
   -> Maybe Text
+  -> [ExtendedProperty]
+  -> [ExtendedProperty]
   -> ClientM Response.CalendarEventList
 postCalendarEvent' ::
      Text
@@ -205,8 +211,10 @@ getCalendarEventList ::
   -> Maybe Form.DateTime
   -> Maybe Form.DateTime
   -> Maybe Text
+  -> [ExtendedProperty]
+  -> [ExtendedProperty]
   -> IO (Either ClientError Response.CalendarEventList)
-getCalendarEventList token calendarId singleEvents timeMin timeMax orderBy = do
+getCalendarEventList token calendarId singleEvents timeMin timeMax orderBy privateExtendedProperties sharedExtendedProperties = do
   manager <- newManager tlsManagerSettings
   runClientM
     (getCalendarEventList'
@@ -215,7 +223,9 @@ getCalendarEventList token calendarId singleEvents timeMin timeMax orderBy = do
        singleEvents
        timeMin
        timeMax
-       orderBy)
+       orderBy
+       privateExtendedProperties
+       sharedExtendedProperties)
     (mkClientEnv manager googleBaseUrl)
 
 postCalendarEvent ::

--- a/src/Google/Form.hs
+++ b/src/Google/Form.hs
@@ -11,6 +11,8 @@ module Google.Form
   , GmailSend(..)
   , Account(..)
   , DateTime(..)
+  , ExtendedProperty(..)
+  , ExtendedProperties(..)
   , Email(..)
   , toMail
   , MultipartBody(..)
@@ -38,6 +40,7 @@ import Network.Mail.Mime (Address(..), Mail(..), renderAddress, simpleMail)
 import Servant.API (MimeRender(..))
 import Web.FormUrlEncoded (Form(..), ToForm(toForm))
 import Web.HttpApiData (ToHttpApiData(..))
+import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 
 import Google.Type
@@ -67,6 +70,21 @@ newtype DateTime = DateTime
 
 deriveJSON defaultOptions ''DateTime
 
+newtype ExtendedProperty = ExtendedProperty
+  { pair :: (Text, Text)
+  } deriving (Eq, Generic, Show, Typeable)
+
+instance ToHttpApiData ExtendedProperty where
+  toQueryParam ExtendedProperty {..} =
+    fst pair <> "=" <> snd pair
+
+data ExtendedProperties = ExtendedProperties
+  { private :: HashMap Text Text
+  , shared :: HashMap Text Text
+  } deriving (Eq, Generic, Show, Typeable)
+
+deriveJSON defaultOptions ''ExtendedProperties
+
 data CalendarEvent = CalendarEvent
   { creator :: Account
   , attendees :: [Account]
@@ -74,6 +92,7 @@ data CalendarEvent = CalendarEvent
   , description :: Text
   , start :: DateTime
   , end :: DateTime
+  , extendedProperties :: Maybe ExtendedProperties
   } deriving (Eq, Generic, Show, Typeable)
 
 deriveJSON defaultOptions ''CalendarEvent


### PR DESCRIPTION
This PR makes it possible to:
* insert event with extended properties.
* get events which have specific extended properties.

[Here](https://github.com/qunoissue/tonatona-google-server-api/tree/update-dependencies/sample) is sample application of new `postCalendarEvent` and `getCalendarEventList`.

cf. 
https://developers.google.com/calendar/api/v3/reference/events/insert
https://developers.google.com/calendar/api/v3/reference/events/list