### PR TITLE
feat: Add OAuth scope for spreadsheets

### DIFF
--- a/google-server-api.cabal
+++ b/google-server-api.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           google-server-api
-version:        0.4.0.2
+version:        0.4.0.3
 synopsis:       Google APIs for server to server applications
 description:    This library provides a way to use Google API for server to server applications.
 category:       Web

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: google-server-api
-version: "0.4.0.2"
+version: "0.4.0.3"
 category: "Web"
 synopsis: "Google APIs for server to server applications"
 description:

--- a/src/Google/JWT.hs
+++ b/src/Google/JWT.hs
@@ -82,6 +82,7 @@ data Scope
   | ScopeGmailSend
   | ScopeDriveFile
   | ScopeDriveMetadataRead
+  | ScopeSpreadsheets
   deriving (Eq, Show, Read, Ord)
 
 {-| Make sure if you added new scope, update configuration in page bellow.
@@ -94,6 +95,7 @@ scopeUrl ScopeGmailSend = "https://www.googleapis.com/auth/gmail.send"
 scopeUrl ScopeGmailFull = "https://www.googleapis.com/auth/gmail"
 scopeUrl ScopeDriveFile = "https://www.googleapis.com/auth/drive.file"
 scopeUrl ScopeDriveMetadataRead = "https://www.googleapis.com/auth/drive.metadata.readonly"
+scopeUrl ScopeSpreadsheets = "https://www.googleapis.com/auth/spreadsheets"
 
 -- | Get the private key obtained from the
 -- Google API Console from a PEM 'String'.


### PR DESCRIPTION
Hi!

This is a PR adding OAuth2 scope for `spreadsheets`, since some methods from Google Sheets API v4 requires them to work correctly.

## Detailed motivation

I've been building a Haskell web app writes to Google Spreadsheets via Sheets API and adopted JWT functions from this package. Then I ran into a problem.

The reference document of Sheets API says that they would be accessible through `drive` or `drive.files` scope, and that is right for some cases:

https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append#authorization-scopes

But I found that there are exceptions. For example. `spreadsheets.values.append` can be accessed via `drive.files` scope but it fails to an error saying "Requested entity was not found".

According to [this SF entry](https://stackoverflow.com/questions/57228059/getting-requested-entity-was-not-found-when-fetching-google-sheets-data-using), `drive.files` scope indeed grant write access to spreadsheets but only for those you have created through that very same API access. Otherwise the resources will be invisible.

I'd very appreciate if you could have a minute or two to look around! :hugs: